### PR TITLE
Don't include_recipe passenger in repo recipe

### DIFF
--- a/recipes/repo_passenger.rb
+++ b/recipes/repo_passenger.rb
@@ -34,6 +34,4 @@ when 'debian'
     keyserver 'keyserver.ubuntu.com'
     key '561F9B9CAC40B2F7'
   end
-
-  include_recipe 'nginx::passenger'
 end


### PR DESCRIPTION
Doing this include at this point, before nginx package is installed, breaks default or package recipe on first run if using passenger repos (because config dir doesn't yet exist when writing passenger.conf). It does mean you have to include_recipe 'nginx::passenger' later yourself. 

This doesn't seem unreasonable, but would account to a breaking change for people who were depending on implicit inclusion (though the packages and config files are likely already in place for them)

A safer version of this would do the include at this point if nginx already installed but defer it to end of package recipe if first-install

Another alternative might be to switch the writing of the config to a delayed notification off ... something

A super ugly workaround with the current cookbook for an initial install can be achieved as follows:

``` ruby
ignore_further_includes = run_context.send(:loaded_recipes_hash)
ignore_further_includes['nginx::passenger'] = true
include_recipe 'nginx'
ignore_further_includes.delete('nginx::passenger')
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/miketheman/nginx/390)

<!-- Reviewable:end -->
