### PR TITLE
Allow newer versions of passenger to be installed

### DIFF
--- a/recipes/passenger.rb
+++ b/recipes/passenger.rb
@@ -35,15 +35,19 @@ if node['nginx']['passenger']['install_method'] == 'package'
   package node['nginx']['package_name']
   package 'passenger'
 elsif node['nginx']['passenger']['install_method'] == 'source'
-
   gem_package 'passenger' do
     action     :install
     version    node['nginx']['passenger']['version']
     gem_binary node['nginx']['passenger']['gem_binary'] if node['nginx']['passenger']['gem_binary']
   end
 
+  path = '/ext/nginx'
+  if node['nginx']['passenger']['version'] == '5.0.19' || node['nginx']['passenger']['version'] =~ /5\.\d*\.[2-9]\d?/
+    path = '/src/nginx_module'
+  end
+
   node.run_state['nginx_configure_flags'] =
-    node.run_state['nginx_configure_flags'] | ["--add-module=#{node['nginx']['passenger']['root']}/ext/nginx"]
+    node.run_state['nginx_configure_flags'] | ["--add-module=#{node['nginx']['passenger']['root']}#{path}"]
 
 end
 


### PR DESCRIPTION
Hi All, I now that you are focusing on 3.0 now.  But, there is a breaking change for Passenger after version 5.0.19. Passenger changed the location of its native nginx module code from ext/nginx to src/nginx_module.  This change fixes that so that the latest versions of Passenger will not break the 2.7.x branch.

Thanks,

Josh

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/miketheman/nginx/394)

<!-- Reviewable:end -->
