### PR TITLE
Add support for HTTP/2 nginx module

### DIFF
--- a/recipes/http_v2_module.rb
+++ b/recipes/http_v2_module.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: nginx
+# Recipe:: http_v2_module
+#
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+node.run_state['nginx_configure_flags'] =
+  node.run_state['nginx_configure_flags'] | ['--with-http_v2_module']


### PR DESCRIPTION
HTTP/2 replaces SPDY as of nginx 1.9.5 (see http://nginx.org/en/docs/http/ngx_http_v2_module.html). This recipe just enables the http_v2_module.

(Note for anyone wanting to use this in your kitchen, use my 2.7.x branch to get support for Passenger >5.0.19 and HTTP/2. E.g., in your Berksfile: `cookbook 'nginx', github: 'whatcould/nginx', tag: '2.7.x'` )

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/miketheman/nginx/395)

<!-- Reviewable:end -->
