### PR TITLE
configure path to /usr/bin

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -103,6 +103,7 @@ bash 'compile_nginx_source' do
     cd nginx-#{node['nginx']['source']['version']} &&
     ./configure #{node.run_state['nginx_configure_flags'].join(' ')} &&
     make && make install
+    ln -sf #{File.dirname(src_filepath)}/sbin/nginx /usr/bin/nginx
   EOH
 
   not_if do


### PR DESCRIPTION
Enable to use command `nginx` when nginx is installed via source compile.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/miketheman/nginx/396)

<!-- Reviewable:end -->
