### PR TITLE
Change dependency on old version of apt recipe

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ version           '2.7.6'
 recipe 'nginx',         'Installs nginx package and sets up configuration with Debian apache style with sites-enabled/sites-available'
 recipe 'nginx::source', 'Installs nginx from source and sets up configuration with Debian apache style with sites-enabled/sites-available'
 
-depends 'apt'              '>= 2.2'
+depends 'apt',             '>= 2.2'
 depends 'bluepill',        '~> 2.3'
 depends 'build-essential', '~> 2.0'
 depends 'ohai',            '~> 2.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ version           '2.7.6'
 recipe 'nginx',         'Installs nginx package and sets up configuration with Debian apache style with sites-enabled/sites-available'
 recipe 'nginx::source', 'Installs nginx from source and sets up configuration with Debian apache style with sites-enabled/sites-available'
 
-depends 'apt',             '~> 2.2'
+depends 'apt'              '>= 2.2'
 depends 'bluepill',        '~> 2.3'
 depends 'build-essential', '~> 2.0'
 depends 'ohai',            '~> 2.0'


### PR DESCRIPTION
Change this dependency to remove conflict with recipes already asking for apt greater than 2.2

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/miketheman/nginx/399)

<!-- Reviewable:end -->
