### PR TITLE
Remove Apt version lock

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,5 +2,5 @@ source 'https://supermarket.chef.io'
 metadata
 
 group :integration do
-  cookbook 'apt', '~> 2.0'
+  cookbook 'apt'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ version           '2.7.6'
 recipe 'nginx',         'Installs nginx package and sets up configuration with Debian apache style with sites-enabled/sites-available'
 recipe 'nginx::source', 'Installs nginx from source and sets up configuration with Debian apache style with sites-enabled/sites-available'
 
-depends 'apt',             '~> 2.2'
+depends 'apt'
 depends 'bluepill',        '~> 2.3'
 depends 'build-essential', '~> 2.0'
 depends 'ohai',            '~> 2.0'


### PR DESCRIPTION
Remove the Apt version lock (currently locked to 2.0 in Berksfile, and 2.2 in metadata. This doesn't seem to be necessary, and in larger environment cookbooks, causes problems.

Tested and working with Apt 4.0.0

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/miketheman/nginx/416)

<!-- Reviewable:end -->
