### PR TITLE
Correctly compare versions greater than 9

### DIFF
--- a/templates/default/modules/http_realip.conf.erb
+++ b/templates/default/modules/http_realip.conf.erb
@@ -2,6 +2,6 @@
 set_real_ip_from <%= address %>;
 <% end %>
 real_ip_header <%= node['nginx']['realip']['header'] %>;
-<% if node['nginx']['version'] >= '1.2.1' -%>
+<% if Gem::Version.new(node['nginx']['version']) >= Gem::Version.new('1.2.1') -%>
 real_ip_recursive <%= node['nginx']['realip']['real_ip_recursive'] %>;
 <% end -%>


### PR DESCRIPTION
Existing code compares version numbers lexically resulting in "1.10.x" being considered a lower version than "1.2.x".

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/miketheman/nginx/425)

<!-- Reviewable:end -->
