### PR TITLE
Reload nginx on site config changes

### DIFF
--- a/definitions/nginx_site.rb
+++ b/definitions/nginx_site.rb
@@ -26,6 +26,7 @@ define :nginx_site, :enable => true, :timing => :delayed do
       template "#{node['nginx']['dir']}/sites-available/#{params[:name]}" do
         source params[:template]
         variables(params[:variables])
+        notifies :reload, 'service[nginx]', params[:timing]
       end
     end
 


### PR DESCRIPTION
When making changes to site configuration templates, there existed a situation where the nginx service would not restart. This change notifies reload upon template changes of any type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/miketheman/nginx/431)
<!-- Reviewable:end -->
