### PR TITLE
Abstract nginx users home path to attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Generally used attributes. Some have platform specific values. See `attributes/d
 - `node['nginx']['log_dir']` - Location for nginx logs.
 - `node['nginx']['log_dir_perm']` - Permissions for nginx logs folder.
 - `node['nginx']['user']` - User that nginx will run as.
+- `node['nginx']['user_home']` - User home path, used during user creation.
 - `node['nginx']['group']` - Group for nginx.
 - `node['nginx']['port']` - Port for nginx to listen on.
 - `node['nginx']['binary']` - Path to the nginx binary.
@@ -229,7 +230,7 @@ These attributes are used in the `nginx::source` recipe. Some of them are dynami
 - `node['nginx']['source']['modules']` - Array of modules that should be compiled into nginx by including their recipes in `nginx::source`.
 - `node['nginx']['source']['default_configure_flags']` - The default flags passed to the configure script when building nginx.
 - `node['nginx']['configure_flags']` - Preserved for compatibility and dynamically generated from the `node['nginx']['source']['default_configure_flags']` in the `nginx::source` recipe.
-- `node['nginx']['source']['use_existing_user']` - set to `true` if you do not want `nginx::source` recipe to create system user with name `node['nginx']['user']`.
+- `node['nginx']['source']['use_existing_user']` - set to `true` if you do not want `nginx::source` recipe to create system user with name `node['nginx']['user']` and `node['nginx']['user_home']`.
 
 ### nginx::status
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -60,6 +60,8 @@ else # debian probably
   default['nginx']['user']       = 'www-data'
 end
 
+default['nginx']['user_home'] = '/var/www'
+
 default['nginx']['upstart']['runlevels']     = '2345'
 default['nginx']['upstart']['respawn_limit'] = nil
 default['nginx']['upstart']['foreground']    = true

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -29,7 +29,8 @@ node.normal['nginx']['daemon_disable'] = true
 user node['nginx']['user'] do
   system true
   shell  '/bin/false'
-  home   '/var/www'
+  home   node['nginx']['user_home']
+  manage_home true
   not_if { node['nginx']['source']['use_existing_user'] }
 end
 


### PR DESCRIPTION
### Description

Allows for overriding the home path of nginx user during source installs.
Default to previously hard coded path.

Chef 12.21.12 nor 13.5.3 do not create home_dir so added `manage_home true`

Signed-off-by: Wade Peacock <wade.peacock@visioncritical.com>

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
