### PR TITLE
Fix false positive for recompiling

### DIFF
--- a/attributes/source.rb
+++ b/attributes/source.rb
@@ -38,7 +38,7 @@ default['nginx']['source']['default_configure_flags'] = %W(
   --prefix=#{node['nginx']['source']['prefix']}
   --conf-path=#{node['nginx']['dir']}/nginx.conf
   --sbin-path=#{node['nginx']['source']['sbin_path']}
-  --with-cc-opt="-Wno-error"
+  --with-cc-opt=-Wno-error
 )
 
 default['nginx']['configure_flags']    = []


### PR DESCRIPTION
### Description

It seems like `node.automatic_attrs['nginx']['configure_arguments']` omits the quotes for this argument, creating a false positive for recompiling. Removing the quotes at all fixes the issue.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
