### PR TITLE
Added service for repo_passenger recipe.

### DIFF
--- a/recipes/repo_passenger.rb
+++ b/recipes/repo_passenger.rb
@@ -33,3 +33,8 @@ else
     level :warn
   end
 end
+
+service 'nginx' do
+  supports status: true, restart: true, reload: true
+  action   [:start, :enable]
+end


### PR DESCRIPTION


### Description

Cookbook fails when installing repo passenger because there is no service declaration inline.  This fixes that issue.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>