### PR TITLE
updated flag to control service installtion

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -126,3 +126,6 @@ default['nginx']['default']['modules']          = []
 default['nginx']['extra_configs'] = {}
 
 default['nginx']['load_modules'] = []
+
+#service flag controls intallation of the services in container which dont have systemd
+default['nginx']['require_service'] = 'false'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,6 +23,6 @@ nginx_cleanup_runit 'cleanup' if node['nginx']['cleanup_runit']
 
 include_recipe "nginx::#{node['nginx']['install_method']}"
 
-node['nginx']['default']['modules'].each do |ngx_module|
-  include_recipe "nginx::#{ngx_module}"
-end
+#node['nginx']['default']['modules'].each do |ngx_module|
+#  include_recipe "nginx::#{ngx_module}"
+#end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,6 +23,6 @@ nginx_cleanup_runit 'cleanup' if node['nginx']['cleanup_runit']
 
 include_recipe "nginx::#{node['nginx']['install_method']}"
 
-#node['nginx']['default']['modules'].each do |ngx_module|
-#  include_recipe "nginx::#{ngx_module}"
-#end
+node['nginx']['default']['modules'].each do |ngx_module|
+  include_recipe "nginx::#{ngx_module}"
+end

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -48,6 +48,7 @@ end
 include_recipe 'nginx::commons'
 
 service 'nginx' do
+  only_if { node['nginx']['require_service'] }
   supports status: true, restart: true, reload: true
   action   [:start, :enable]
 end


### PR DESCRIPTION
### Description
 Some container dont have systemd in them and just should be able to run one service. so I added control flag that will give user ability to control the service installtion
### Issues Resolved
Deployment on docker containers without systemd in them
### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
