### PR TITLE
source shouldn't determine if streams enabled

### DIFF
--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -122,8 +122,8 @@ http {
   include <%= node['nginx']['dir'] %>/conf.d/*.conf;
   include <%= node['nginx']['dir'] %>/sites-enabled/*;
 }
-<% if node['nginx']['install_method'] == 'source' and  node['nginx']['configure_flags'].include? '--with-stream'  %>
-stream{
+<% if node['nginx']['configure_flags'].include? '--with-stream'  %>
+stream {
   include <%= node['nginx']['dir'] %>/streams-enabled/*;
 }
 <% end %>


### PR DESCRIPTION
### Description

[Describe what this change achieves]
The steams should be added if the --with-streams flag is set. The install method should not matter.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
